### PR TITLE
Allocate units to Prime slots first (fixes #5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,4 +52,4 @@ Single-page application with:
 - **Sub-faction**: Specific legion or variant within a faction
 - **Detachment**: A structure containing slots that units fill
 - **Battlefield Role**: Unit category (HQ, Troops, Elites, etc.)
-- **Prime**: A rule allowing flexible slot usage (prefer not to use when allocating)
+- **Prime**: A rule allowing flexible slot usage (allocated first to enable Logistical Benefit)

--- a/src/allocation/slot-matcher.ts
+++ b/src/allocation/slot-matcher.ts
@@ -58,13 +58,13 @@ export function findAvailableSlot(
   slots: AllocatedSlot[],
   detachmentFaction: FactionId,
   detachmentSubFaction?: SubFactionId,
-  preferNonPrime: boolean = true
+  preferPrime: boolean = true
 ): AllocatedSlot | null {
-  // First pass: find non-prime slots
-  if (preferNonPrime) {
+  // First pass: find Prime slots first
+  if (preferPrime) {
     for (const slot of slots) {
       if (slot.unitId) continue;
-      if (slot.isPrime) continue;
+      if (!slot.isPrime) continue;
 
       const result = canUnitFillSlot(
         unit,


### PR DESCRIPTION
## Summary
- Changed slot allocation algorithm to prefer Prime slots over non-Prime slots
- Removed unnecessary `enableLogisticalBenefitByMovingUnits()` function since units are now allocated to Prime slots first
- Updated CLAUDE.md documentation to reflect the new behaviour

## Test plan
- [ ] Run `pnpm build` to verify the project compiles
- [ ] Run `pnpm dev` and add units that can fill Prime slots
- [ ] Verify units are allocated to Prime slots first
- [ ] Verify non-Prime slots are only used after Prime slots are full
- [ ] Verify Logistical Benefit still works correctly

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/claude-code)