### PR TITLE
Add GitHub issues link to footer

### DIFF
--- a/src/ui/footer.ts
+++ b/src/ui/footer.ts
@@ -4,6 +4,7 @@ export function renderFooter(): string {
       <p>Detachmentizer HH3 - Unofficial army builder helper</p>
       <p>Warhammer: The Horus Heresy is &copy; Games Workshop Ltd.</p>
       <p>This tool is not affiliated with Games Workshop.</p>
+      <p><a href="https://github.com/edward3h/detachmentizer-hh3/issues" target="_blank" rel="noopener noreferrer">Report an issue or request a feature</a></p>
     </footer>
   `;
 }


### PR DESCRIPTION
## Summary
- Added a link to the GitHub issues page in the footer
- Allows users to easily report issues or request features

## Test plan
- [ ] Run `pnpm dev` and verify the link appears in the footer
- [ ] Click the link and verify it opens the GitHub issues page

🤖 Generated with [Claude Code](https://claude.ai/claude-code)