### PR TITLE
Replace unit button text with icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Detachmentizer HH3</title>
+    <link rel="stylesheet" href="https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css" />
     <link rel="stylesheet" href="/src/styles/theme.css" />
     <link rel="stylesheet" href="/src/styles/main.css" />
   </head>

--- a/src/ui/unit-list.ts
+++ b/src/ui/unit-list.ts
@@ -51,8 +51,8 @@ export function renderUnitList(army: ArmyState): string {
             <span class="unit-name">${unit.name}</span>
             ${factionDisplay}
           </div>
-          <button class="btn-small duplicate-unit" data-unit-id="${unit.id}">Duplicate</button>
-          <button class="btn-danger btn-small remove-unit" data-unit-id="${unit.id}">Remove</button>
+          <button class="btn-small duplicate-unit" data-unit-id="${unit.id}" title="Duplicate"><i class="la la-copy"></i></button>
+          <button class="btn-danger btn-small remove-unit" data-unit-id="${unit.id}" title="Remove"><i class="la la-trash"></i></button>
         </li>
       `;
     })
@@ -71,7 +71,8 @@ export function renderUnitList(army: ArmyState): string {
 export function setupUnitListHandlers(): void {
   document.querySelectorAll('.remove-unit').forEach((btn) => {
     btn.addEventListener('click', (e) => {
-      const unitId = (e.target as HTMLElement).dataset.unitId;
+      const button = (e.target as HTMLElement).closest('.remove-unit') as HTMLElement;
+      const unitId = button?.dataset.unitId;
       if (unitId) {
         appState.removeUnit(unitId);
       }
@@ -80,7 +81,8 @@ export function setupUnitListHandlers(): void {
 
   document.querySelectorAll('.duplicate-unit').forEach((btn) => {
     btn.addEventListener('click', (e) => {
-      const unitId = (e.target as HTMLElement).dataset.unitId;
+      const button = (e.target as HTMLElement).closest('.duplicate-unit') as HTMLElement;
+      const unitId = button?.dataset.unitId;
       if (unitId) {
         const army = appState.getArmy();
         const unit = army?.units.find((u) => u.id === unitId);


### PR DESCRIPTION
## Summary

- Add Line Awesome icon library via CDN
- Replace "Duplicate" text with copy icon
- Replace "Remove" text with trash icon
- Add tooltips for accessibility
- Fix event handlers to use `closest()` for icon click targets

## Test plan

- [ ] Add a unit to the list
- [ ] Verify copy and trash icons display correctly
- [ ] Hover over icons to confirm tooltips appear
- [ ] Click icons to verify duplicate and remove still work

🤖 Generated with [Claude Code](https://claude.ai/code)