### PR TITLE
Use grid layout for unit list

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -185,18 +185,22 @@ label {
 /* Unit list */
 .unit-list {
   list-style: none;
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: var(--space-xs) var(--space-sm);
 }
 
 .unit-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--space-sm);
-  border-bottom: 1px solid var(--color-border-light);
+  display: contents;
 }
 
-.unit-item:last-child {
-  border-bottom: none;
+.unit-item > :first-child {
+  padding-left: var(--space-sm);
+}
+
+.unit-item > :last-child {
+  padding-right: var(--space-sm);
 }
 
 .unit-role {
@@ -204,6 +208,13 @@ label {
   color: var(--color-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+.unit-info {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .unit-name {

--- a/src/ui/unit-list.ts
+++ b/src/ui/unit-list.ts
@@ -46,8 +46,8 @@ export function renderUnitList(army: ArmyState): string {
 
       return `
         <li class="unit-item" data-unit-id="${unit.id}">
-          <div>
-            <span class="unit-role">${getBattlefieldRoleName(unit.role)}</span>
+          <span class="unit-role">${getBattlefieldRoleName(unit.role)}</span>
+          <div class="unit-info">
             <span class="unit-name">${unit.name}</span>
             ${factionDisplay}
           </div>


### PR DESCRIPTION
## Summary

- Apply CSS grid to the unit list container for consistent column alignment
- Use `display: contents` on list items so children participate in parent grid
- Unit names now align across all rows

## Test plan

- [ ] Run `pnpm dev` and add several units
- [ ] Verify role labels align in the first column
- [ ] Verify unit names align in the second column
- [ ] Verify buttons align in the last columns

🤖 Generated with [Claude Code](https://claude.ai/code)