### PR TITLE
Reorganise footer into three-column layout

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -323,7 +323,53 @@ label {
   border-top: 1px solid var(--color-border-light);
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: start;
+  gap: var(--space-md);
+}
+
+.footer-left {
+  text-align: left;
+}
+
+.footer-centre {
   text-align: center;
+}
+
+.footer-right {
+  text-align: right;
+}
+
+.app-footer a {
+  color: var(--color-primary);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.app-footer a:hover {
+  color: var(--color-primary-hover);
+}
+
+.app-footer .icon {
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+  color: var(--color-text);
+}
+
+@media (max-width: 600px) {
+  .app-footer {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .footer-left,
+  .footer-centre,
+  .footer-right {
+    text-align: center;
+  }
 }
 
 /* Typeahead */

--- a/src/ui/footer.ts
+++ b/src/ui/footer.ts
@@ -11,11 +11,20 @@ export function renderFooter(): string {
 
   return `
     <footer class="app-footer">
-      <p>Detachmentizer HH3 - Unofficial army builder helper</p>
-      <p>Warhammer: The Horus Heresy is &copy; Games Workshop Ltd.</p>
-      <p>This tool is not affiliated with Games Workshop.</p>
-      <p><a href="https://github.com/edward3h/detachmentizer-hh3/issues" target="_blank" rel="noopener noreferrer">Report an issue or request a feature</a></p>
-      <p class="build-info">Built: ${buildTime}</p>
+      <div class="footer-left">
+        <a href="https://github.com/edward3h/detachmentizer-hh3/issues" target="_blank" rel="noopener noreferrer">
+          <svg class="icon" viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          Report an issue or request a feature
+        </a>
+      </div>
+      <div class="footer-centre">
+        <p>Detachmentizer HH3 - Unofficial army builder helper</p>
+        <p>Warhammer: The Horus Heresy is &copy; Games Workshop Ltd.</p>
+        <p>This tool is not affiliated with Games Workshop.</p>
+      </div>
+      <div class="footer-right">
+        <p class="build-info">Built: ${buildTime}</p>
+      </div>
     </footer>
   `;
 }


### PR DESCRIPTION
## Summary
- Reorganise footer into three columns: GitHub link (left), app info (centre), build timestamp (right)
- Add GitHub icon to the issues link
- Improve link contrast for dark mode using primary colour
- Add responsive behaviour: columns stack vertically on screens ≤600px

## Test plan
- [ ] Verify footer displays correctly in three columns on desktop
- [ ] Resize browser to verify responsive stacking on narrow screens
- [ ] Test in both light and dark modes
- [ ] Verify GitHub icon displays correctly in both themes

🤖 Generated with [Claude Code](https://claude.ai/code)