### PR TITLE
Add YAML save/load feature for army data

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "typescript-eslint": "^8.22.0",
     "vite": "^7.0.0",
     "vitest": "^4.0.18"
+  },
+  "dependencies": {
+    "yaml": "^2.8.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
     devDependencies:
       '@eslint/js':
         specifier: ^9.19.0
@@ -25,10 +29,10 @@ importers:
         version: 8.54.0(eslint@9.39.2)(typescript@5.9.3)
       vite:
         specifier: ^7.0.0
-        version: 7.3.1
+        version: 7.3.1(yaml@2.8.2)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18
+        version: 4.0.18(yaml@2.8.2)
 
 packages:
 
@@ -955,6 +959,11 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1286,13 +1295,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1)':
+  '@vitest/mocker@4.0.18(vite@7.3.1(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1
+      vite: 7.3.1(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -1717,7 +1726,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@7.3.1:
+  vite@7.3.1(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -1727,11 +1736,12 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       fsevents: 2.3.3
+      yaml: 2.8.2
 
-  vitest@4.0.18:
+  vitest@4.0.18(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1)
+      '@vitest/mocker': 4.0.18(vite@7.3.1(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -1748,7 +1758,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1
+      vite: 7.3.1(yaml@2.8.2)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti
@@ -1773,5 +1783,7 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  yaml@2.8.2: {}
 
   yocto-queue@0.1.0: {}

--- a/src/io/export-army.ts
+++ b/src/io/export-army.ts
@@ -1,0 +1,54 @@
+import { stringify } from 'yaml';
+import type { ArmyState } from '../types';
+import type { YamlArmyFile, YamlUnitData, YamlArmyData } from './yaml-schema';
+import { CURRENT_YAML_VERSION } from './yaml-schema';
+
+function convertArmyToYaml(army: ArmyState | null): YamlArmyData | null {
+  if (!army) {
+    return null;
+  }
+
+  const units: YamlUnitData[] = army.units.map((unit) => {
+    const yamlUnit: YamlUnitData = {
+      name: unit.name,
+      role: unit.role,
+      faction: unit.faction,
+    };
+
+    if (unit.subFaction) {
+      yamlUnit.subFaction = unit.subFaction;
+    }
+
+    if (unit.officerOfTheLine !== undefined) {
+      yamlUnit.officerOfTheLine = unit.officerOfTheLine;
+    }
+
+    return yamlUnit;
+  });
+
+  const yamlArmy: YamlArmyData = {
+    allegiance: army.allegiance,
+    primaryFaction: army.primaryFaction,
+    units,
+  };
+
+  if (army.primarySubFaction) {
+    yamlArmy.primarySubFaction = army.primarySubFaction;
+  }
+
+  return yamlArmy;
+}
+
+export function exportArmyToYaml(army: ArmyState | null, customUnitNames: string[]): string {
+  const yamlFile: YamlArmyFile = {
+    version: CURRENT_YAML_VERSION,
+    exportedAt: new Date().toISOString(),
+    army: convertArmyToYaml(army),
+    customUnitNames,
+  };
+
+  return stringify(yamlFile, {
+    indent: 2,
+    lineWidth: 0,
+  });
+}

--- a/src/io/file-download.ts
+++ b/src/io/file-download.ts
@@ -1,0 +1,18 @@
+export function downloadFile(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+
+  document.body.appendChild(link);
+  link.click();
+
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export function downloadYamlFile(content: string, filename: string): void {
+  downloadFile(content, filename, 'application/x-yaml');
+}

--- a/src/io/file-upload.ts
+++ b/src/io/file-upload.ts
@@ -1,0 +1,46 @@
+export function openFilePicker(accept: string): Promise<File | null> {
+  return new Promise((resolve) => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = accept;
+    input.style.display = 'none';
+
+    input.addEventListener('change', () => {
+      const file = input.files?.[0] ?? null;
+      document.body.removeChild(input);
+      resolve(file);
+    });
+
+    input.addEventListener('cancel', () => {
+      document.body.removeChild(input);
+      resolve(null);
+    });
+
+    document.body.appendChild(input);
+    input.click();
+  });
+}
+
+export function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      resolve(reader.result as string);
+    };
+
+    reader.onerror = () => {
+      reject(new Error(`Failed to read file: ${reader.error?.message ?? 'Unknown error'}`));
+    };
+
+    reader.readAsText(file);
+  });
+}
+
+export async function openAndReadYamlFile(): Promise<string | null> {
+  const file = await openFilePicker('.yaml,.yml');
+  if (!file) {
+    return null;
+  }
+  return readFileAsText(file);
+}

--- a/src/io/import-army.ts
+++ b/src/io/import-army.ts
@@ -1,0 +1,70 @@
+import { parse } from 'yaml';
+import type { ArmyState, Unit } from '../types';
+import { createUnit } from '../types';
+import type { YamlArmyFile, YamlArmyData } from './yaml-schema';
+import { validateYamlArmyFile } from './yaml-schema';
+
+export interface ImportResult {
+  success: true;
+  army: ArmyState | null;
+  customUnitNames: string[];
+}
+
+export interface ImportError {
+  success: false;
+  error: string;
+}
+
+export type ImportOutcome = ImportResult | ImportError;
+
+function convertYamlToArmy(yamlArmy: YamlArmyData | null): ArmyState | null {
+  if (!yamlArmy) {
+    return null;
+  }
+
+  const units: Unit[] = yamlArmy.units.map((yamlUnit) =>
+    createUnit(
+      yamlUnit.name,
+      yamlUnit.role,
+      yamlUnit.faction,
+      yamlUnit.subFaction,
+      yamlUnit.officerOfTheLine
+    )
+  );
+
+  const army: ArmyState = {
+    allegiance: yamlArmy.allegiance,
+    primaryFaction: yamlArmy.primaryFaction,
+    units,
+  };
+
+  if (yamlArmy.primarySubFaction) {
+    army.primarySubFaction = yamlArmy.primarySubFaction;
+  }
+
+  return army;
+}
+
+export function importArmyFromYaml(yamlContent: string): ImportOutcome {
+  let parsed: unknown;
+
+  try {
+    parsed = parse(yamlContent);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return { success: false, error: `Failed to parse YAML: ${message}` };
+  }
+
+  const validation = validateYamlArmyFile(parsed);
+  if (!validation.valid) {
+    return { success: false, error: validation.error! };
+  }
+
+  const yamlFile = parsed as YamlArmyFile;
+
+  return {
+    success: true,
+    army: convertYamlToArmy(yamlFile.army),
+    customUnitNames: yamlFile.customUnitNames,
+  };
+}

--- a/src/io/index.ts
+++ b/src/io/index.ts
@@ -1,0 +1,11 @@
+export { exportArmyToYaml } from './export-army';
+export {
+  importArmyFromYaml,
+  type ImportResult,
+  type ImportError,
+  type ImportOutcome,
+} from './import-army';
+export { downloadYamlFile } from './file-download';
+export { openAndReadYamlFile } from './file-upload';
+export { CURRENT_YAML_VERSION, validateYamlArmyFile } from './yaml-schema';
+export type { YamlArmyFile, YamlArmyData, YamlUnitData, ValidationResult } from './yaml-schema';

--- a/src/io/yaml-schema.ts
+++ b/src/io/yaml-schema.ts
@@ -1,0 +1,208 @@
+import type { Allegiance } from '../types/allegiance';
+import type { BattlefieldRole } from '../types/battlefield-role';
+import type { FactionId, SubFactionId } from '../types/faction';
+
+export const CURRENT_YAML_VERSION = 1;
+
+export interface YamlUnitData {
+  name: string;
+  role: BattlefieldRole;
+  faction: FactionId;
+  subFaction?: SubFactionId;
+  officerOfTheLine?: number;
+}
+
+export interface YamlArmyData {
+  allegiance: Allegiance;
+  primaryFaction: FactionId;
+  primarySubFaction?: SubFactionId;
+  units: YamlUnitData[];
+}
+
+export interface YamlArmyFile {
+  version: number;
+  exportedAt: string;
+  army: YamlArmyData | null;
+  customUnitNames: string[];
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+const VALID_ALLEGIANCES: readonly string[] = ['loyalist', 'traitor'];
+
+const VALID_BATTLEFIELD_ROLES: readonly string[] = [
+  'warlord',
+  'lord-of-war',
+  'high-command',
+  'command',
+  'retinue',
+  'elites',
+  'war-engine',
+  'troops',
+  'support',
+  'transport',
+  'heavy-transport',
+  'heavy-assault',
+  'armour',
+  'recon',
+  'fast-attack',
+];
+
+const VALID_FACTION_IDS: readonly string[] = [
+  'legiones-astartes',
+  'solar-auxilia',
+  'mechanicum',
+  'imperialis-militia',
+  'daemons-of-the-ruinstorm',
+  'cults-abominatio',
+  'knights-errant',
+  'legio-custodes',
+  'anathema-psykana',
+  'divisio-assassinorum',
+  'questoris-familia',
+];
+
+const VALID_SUB_FACTION_IDS: readonly string[] = [
+  'dark-angels',
+  'emperors-children',
+  'iron-warriors',
+  'white-scars',
+  'space-wolves',
+  'imperial-fists',
+  'night-lords',
+  'blood-angels',
+  'iron-hands',
+  'world-eaters',
+  'ultramarines',
+  'death-guard',
+  'thousand-sons',
+  'sons-of-horus',
+  'word-bearers',
+  'salamanders',
+  'raven-guard',
+  'alpha-legion',
+  'blackshields',
+  'shattered-legions',
+];
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function validateUnit(unit: unknown, index: number): ValidationResult {
+  if (!isObject(unit)) {
+    return { valid: false, error: `Unit at index ${index} is not an object` };
+  }
+
+  if (typeof unit.name !== 'string' || unit.name.trim() === '') {
+    return { valid: false, error: `Unit at index ${index} has invalid name` };
+  }
+
+  if (typeof unit.role !== 'string' || !VALID_BATTLEFIELD_ROLES.includes(unit.role)) {
+    return { valid: false, error: `Unit at index ${index} has invalid role: ${unit.role}` };
+  }
+
+  if (typeof unit.faction !== 'string' || !VALID_FACTION_IDS.includes(unit.faction)) {
+    return { valid: false, error: `Unit at index ${index} has invalid faction: ${unit.faction}` };
+  }
+
+  if (
+    unit.subFaction !== undefined &&
+    (typeof unit.subFaction !== 'string' || !VALID_SUB_FACTION_IDS.includes(unit.subFaction))
+  ) {
+    return {
+      valid: false,
+      error: `Unit at index ${index} has invalid subFaction: ${unit.subFaction}`,
+    };
+  }
+
+  if (
+    unit.officerOfTheLine !== undefined &&
+    (typeof unit.officerOfTheLine !== 'number' || unit.officerOfTheLine < 0)
+  ) {
+    return {
+      valid: false,
+      error: `Unit at index ${index} has invalid officerOfTheLine: ${unit.officerOfTheLine}`,
+    };
+  }
+
+  return { valid: true };
+}
+
+function validateArmy(army: unknown): ValidationResult {
+  if (army === null) {
+    return { valid: true };
+  }
+
+  if (!isObject(army)) {
+    return { valid: false, error: 'Army must be an object or null' };
+  }
+
+  if (typeof army.allegiance !== 'string' || !VALID_ALLEGIANCES.includes(army.allegiance)) {
+    return { valid: false, error: `Invalid allegiance: ${army.allegiance}` };
+  }
+
+  if (typeof army.primaryFaction !== 'string' || !VALID_FACTION_IDS.includes(army.primaryFaction)) {
+    return { valid: false, error: `Invalid primaryFaction: ${army.primaryFaction}` };
+  }
+
+  if (
+    army.primarySubFaction !== undefined &&
+    (typeof army.primarySubFaction !== 'string' ||
+      !VALID_SUB_FACTION_IDS.includes(army.primarySubFaction))
+  ) {
+    return { valid: false, error: `Invalid primarySubFaction: ${army.primarySubFaction}` };
+  }
+
+  if (!Array.isArray(army.units)) {
+    return { valid: false, error: 'Army units must be an array' };
+  }
+
+  for (let i = 0; i < army.units.length; i++) {
+    const unitResult = validateUnit(army.units[i], i);
+    if (!unitResult.valid) {
+      return unitResult;
+    }
+  }
+
+  return { valid: true };
+}
+
+export function validateYamlArmyFile(data: unknown): ValidationResult {
+  if (!isObject(data)) {
+    return { valid: false, error: 'File data must be an object' };
+  }
+
+  if (typeof data.version !== 'number') {
+    return { valid: false, error: 'Missing or invalid version field' };
+  }
+
+  if (data.version > CURRENT_YAML_VERSION) {
+    return {
+      valid: false,
+      error: `File version ${data.version} is newer than supported version ${CURRENT_YAML_VERSION}. Please update the application.`,
+    };
+  }
+
+  if (typeof data.exportedAt !== 'string') {
+    return { valid: false, error: 'Missing or invalid exportedAt field' };
+  }
+
+  const armyResult = validateArmy(data.army);
+  if (!armyResult.valid) {
+    return armyResult;
+  }
+
+  if (!isStringArray(data.customUnitNames)) {
+    return { valid: false, error: 'customUnitNames must be an array of strings' };
+  }
+
+  return { valid: true };
+}

--- a/src/state/app-state.ts
+++ b/src/state/app-state.ts
@@ -100,6 +100,12 @@ class AppStateManager {
     clearState();
     this.notify();
   }
+
+  loadFromImport(army: ArmyState | null, customUnitNames: string[]): void {
+    this.state.army = army;
+    this.state.customUnitNames = customUnitNames;
+    this.notify();
+  }
 }
 
 export const appState = new AppStateManager();

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -137,6 +137,12 @@ label {
   margin-bottom: var(--space-sm);
 }
 
+.header-actions {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
 /* Header */
 .app-header {
   background-color: var(--color-bg-secondary);

--- a/src/ui/header.ts
+++ b/src/ui/header.ts
@@ -5,7 +5,10 @@ export function renderHeader(army: ArmyState | null): string {
   if (!army) {
     return `
       <header class="app-header">
-        <h1>Detachmentizer HH3</h1>
+        <div class="card-header">
+          <h1>Detachmentizer HH3</h1>
+          <button class="btn-secondary btn-small" id="load-army">Load</button>
+        </div>
         <p class="text-muted">Army detachment allocation for Warhammer: The Horus Heresy 3rd Edition</p>
       </header>
     `;
@@ -22,7 +25,11 @@ export function renderHeader(army: ArmyState | null): string {
     <header class="app-header">
       <div class="card-header">
         <h1>Detachmentizer HH3</h1>
-        <button class="btn-danger btn-small" id="reset-army">Reset Army</button>
+        <div class="header-actions">
+          <button class="btn-secondary btn-small" id="save-army">Save</button>
+          <button class="btn-secondary btn-small" id="load-army">Load</button>
+          <button class="btn-danger btn-small" id="reset-army">Reset Army</button>
+        </div>
       </div>
       <div>
         <span class="allegiance-badge ${army.allegiance}">${getAllegianceLabel(army.allegiance)}</span>


### PR DESCRIPTION
## Summary
- Add Save button to download army data as a YAML file
- Add Load button to import army data from a YAML file
- Include validation for YAML structure and version checking
- Load button available even when no army exists (to restore saved armies)

## Test plan
- [ ] Create an army with units, click Save, verify YAML file downloads with readable content
- [ ] Click Load, select saved file, verify army is restored correctly
- [ ] Verify Load shows confirmation when army already exists
- [ ] Test loading invalid YAML, verify error message appears
- [ ] Test Load button appears on initial screen (no army)

🤖 Generated with [Claude Code](https://claude.com/claude-code)