### PR TITLE
Add GitHub issue template for allocation bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/allocation-bug.yml
+++ b/.github/ISSUE_TEMPLATE/allocation-bug.yml
@@ -1,0 +1,49 @@
+name: Allocation Bug Report
+description: Report a problem with how units are allocated to detachments
+title: "[Allocation Bug]: "
+labels: ["bug", "allocation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this issue!
+
+        ## How to save your army file
+        1. In the app, click the **Save** button in the header
+        2. A file called `army-YYYY-MM-DD.yaml` will download to your computer
+        3. Attach this file below by dragging it into the upload area
+
+  - type: textarea
+    id: army-file
+    attributes:
+      label: Army File
+      description: Drag and drop your saved .yaml file here, or paste its contents
+      placeholder: Drag your army-YYYY-MM-DD.yaml file here
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should happen
+      description: Describe how you expect the units to be allocated
+      placeholder: "e.g. The Tactical Squad should be placed in the Troops slot of the first detachment"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened
+      description: Describe what the app did instead
+      placeholder: "e.g. The Tactical Squad was placed in the Elites slot instead"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other information that might help (screenshots, browser, etc.)
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Adds a YAML-based issue form template for reporting allocation bugs
- Includes instructions for users on how to save and attach their army YAML file
- Uses structured form fields to guide non-technical users through bug reporting

## Test plan
- [ ] Verify the template appears when creating a new issue on GitHub
- [ ] Test filling out the form and attaching a YAML file
- [ ] Verify the created issue has all sections properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)