### PR TITLE
Add Mechanicum detachments and sub-factions

### DIFF
--- a/docs/mechanicum-detachments.md
+++ b/docs/mechanicum-detachments.md
@@ -1,0 +1,91 @@
+# Mechanicum Detachments
+
+* All of these detachments have the Mechanicum faction.
+* Magos and Magos on Abeyant are units with Officer of the Line (2)
+
+## Sub-factions
+
+* Mechanicum has sub-factions, but they work a little differently from Legiones Astartes sub-factions.
+* In a Primary, Allied or Lord of War detachment, units do not have to have the same sub-faction.
+* In an Apex or Auxiliary detachment, all units must have the same sub-faction.
+* A unit added using Logistical Benefit does not have to have the same sub-faction as the detachment it is added to.
+* Some units have a fixed sub-faction, but I'm not going to list them all.
+
+### List of sub-factions
+
+* Archimandrite
+* Cybernetica
+* Lacrymaerta
+* Myrmidax
+* Reductor
+* Malagra
+* Macrotek
+
+## Auxiliary Detachments
+
+### Taghmata Cohort
+
+* Units:
+  * 4 Support
+
+### Apprentice Cadre
+
+* Slots in this detachment may only be used to select Tech-priest units.
+* Slots:
+  * 4 Troops. 1 is Prime.
+
+## Apex Detachments
+
+### The Heart of Power
+
+* Unlocked by a High Command unit with the Archimandrite sub-faction.
+* Slots:
+  * 3 Retinue. 1 is Prime.
+  * 3 Troops. 3 are Prime. The only Prime rule that can be used for these slots is **Combat Veterans**.
+
+### Command Maniple
+
+* Unlocked by a High Command unit with the Cybernetica sub-faction.
+* This detachment may only contain units with the "Automata" type.
+* Slots:
+  * 1 Elites. 1 is Prime.
+  * 1 Support. 1 is Prime.
+  * 1 War-Engine. 1 is Prime.
+
+### The Panoply of Cruelty
+
+* Unlocked by a High Command unit with the Lacrymaerta sub-faction.
+* Slots in this detachment may only be used to select Ursrax Cohort units.
+* Slots:
+  * 3 Heavy Assault. 3 are Prime.
+
+### The Host of Destruction
+
+* Unlocked by a High Command unit with the Myrmidax sub-faction.
+* This detachment may only contain units with the Myrmidax sub-faction.
+* Slots:
+  * 4 Elites. 1 is Prime.
+
+### Crux of Judgement
+
+* Unlocked by a High Command unit with the Malagra sub-faction.
+* Slots in this detachment may only be used to select Arcuitor Magisterium units.
+* Units in this detachment do not unlock Auxiliary detachments
+* Slots:
+  * 3 Command
+
+### Iron Phalanx
+
+* Unlocked by a High Command unit with the Macrotek sub-faction.
+* Units in this detachment must have the "Vehicle" type.
+* Units in this detachment must have the "Prime Conveyor" Prime rule.
+* Slots:
+  * 3 Armour. 3 are Prime.
+  * 3 Heavy Transport. 3 are Prime.
+
+### Thallax Command Cohort
+
+* Unlocked by a High Command unit with the Reductor sub-faction.
+* Slots in this detachment may only be used to select Thallax Cohort units.
+* Slots:
+  * 3 Support. 3 are Prime.

--- a/src/allocation/allocator.ts
+++ b/src/allocation/allocator.ts
@@ -9,7 +9,12 @@ import type {
   SubFactionId,
   Unit,
 } from '../types';
-import { createAllocatedDetachment, createAllocationResult, createSlotDefinition, FACTIONS } from '../types';
+import {
+  createAllocatedDetachment,
+  createAllocationResult,
+  createSlotDefinition,
+  FACTIONS,
+} from '../types';
 import {
   CORE_DETACHMENTS,
   getApexDetachmentsForFaction,
@@ -29,7 +34,10 @@ interface AlliedFactionContext {
 // Composite key for faction + sub-faction (e.g., "legiones-astartes:salamanders")
 type AlliedContextKey = string;
 
-function makeAlliedContextKey(faction: FactionId, subFaction: SubFactionId | undefined): AlliedContextKey {
+function makeAlliedContextKey(
+  faction: FactionId,
+  subFaction: SubFactionId | undefined
+): AlliedContextKey {
   return subFaction ? `${faction}:${subFaction}` : faction;
 }
 

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -3,6 +3,7 @@ export * from './factions';
 export * from './core-detachments';
 export * from './legiones-astartes';
 export * from './imperialis-militia';
+export * from './mechanicum';
 export * from './known-units';
 
 import type { DetachmentDefinition, FactionId } from '../types';
@@ -13,12 +14,14 @@ import {
 } from './core-detachments';
 import { getAllLegionesAstartesDetachments } from './legiones-astartes';
 import { getAllImperialisMilitiaDetachments } from './imperialis-militia';
+import { getAllMechanicumDetachments } from './mechanicum';
 
 export function getAllDetachments(): DetachmentDefinition[] {
   return [
     ...getAllCoreDetachments(),
     ...getAllLegionesAstartesDetachments(),
     ...getAllImperialisMilitiaDetachments(),
+    ...getAllMechanicumDetachments(),
   ];
 }
 

--- a/src/data/known-units.ts
+++ b/src/data/known-units.ts
@@ -409,6 +409,20 @@ export const KNOWN_UNITS: KnownUnit[] = [
     faction: 'daemons-of-the-ruinstorm',
     fixedAllegiance: 'traitor',
   },
+
+  // Mechanicum - Command units
+  {
+    name: 'Magos',
+    role: 'command',
+    faction: 'mechanicum',
+    officerOfTheLine: 2,
+  },
+  {
+    name: 'Magos on Abeyant',
+    role: 'command',
+    faction: 'mechanicum',
+    officerOfTheLine: 2,
+  },
 ];
 
 export function findKnownUnit(name: string, faction?: string): KnownUnit | undefined {

--- a/src/data/mechanicum.ts
+++ b/src/data/mechanicum.ts
@@ -1,0 +1,98 @@
+import type { DetachmentDefinition } from '../types';
+import { createSlotDefinition } from '../types';
+
+export const MECHANICUM_AUXILIARY_DETACHMENTS: DetachmentDefinition[] = [
+  {
+    id: 'mech-taghmata-cohort',
+    name: 'Taghmata Cohort',
+    category: 'auxiliary',
+    faction: 'mechanicum',
+    slots: [createSlotDefinition('support', 4)],
+  },
+  {
+    id: 'mech-apprentice-cadre',
+    name: 'Apprentice Cadre',
+    category: 'auxiliary',
+    faction: 'mechanicum',
+    slots: [createSlotDefinition('troops', 4, 1, { only: ['Tech-priest'] })],
+    notes: 'Slots may only be used to select Tech-priest units.',
+  },
+];
+
+export const MECHANICUM_APEX_DETACHMENTS: DetachmentDefinition[] = [
+  {
+    id: 'mech-heart-of-power',
+    name: 'The Heart of Power',
+    category: 'apex',
+    faction: 'mechanicum',
+    subFaction: 'archimandrite',
+    slots: [createSlotDefinition('retinue', 3, 1), createSlotDefinition('troops', 3, 3)],
+    notes:
+      'Unlocked by Archimandrite High Command. Troops Prime slots may only use Combat Veterans rule.',
+  },
+  {
+    id: 'mech-command-maniple',
+    name: 'Command Maniple',
+    category: 'apex',
+    faction: 'mechanicum',
+    subFaction: 'cybernetica',
+    slots: [
+      createSlotDefinition('elites', 1, 1),
+      createSlotDefinition('support', 1, 1),
+      createSlotDefinition('war-engine', 1, 1),
+    ],
+    notes: 'Unlocked by Cybernetica High Command. May only contain Automata units.',
+  },
+  {
+    id: 'mech-panoply-of-cruelty',
+    name: 'The Panoply of Cruelty',
+    category: 'apex',
+    faction: 'mechanicum',
+    subFaction: 'lacrymaerta',
+    slots: [createSlotDefinition('heavy-assault', 3, 3, { only: ['Ursrax Cohort'] })],
+    notes: 'Unlocked by Lacrymaerta High Command. Slots may only be used for Ursrax Cohort units.',
+  },
+  {
+    id: 'mech-host-of-destruction',
+    name: 'The Host of Destruction',
+    category: 'apex',
+    faction: 'mechanicum',
+    subFaction: 'myrmidax',
+    slots: [createSlotDefinition('elites', 4, 1)],
+    notes: 'Unlocked by Myrmidax High Command. May only contain Myrmidax units.',
+  },
+  {
+    id: 'mech-crux-of-judgement',
+    name: 'Crux of Judgement',
+    category: 'apex',
+    faction: 'mechanicum',
+    subFaction: 'malagra',
+    slots: [createSlotDefinition('command', 3, 0, { only: ['Arcuitor Magisterium'] })],
+    unitsDoNotUnlockDetachments: true,
+    notes:
+      'Unlocked by Malagra High Command. Slots may only be used for Arcuitor Magisterium units. Units do not unlock Auxiliary detachments.',
+  },
+  {
+    id: 'mech-iron-phalanx',
+    name: 'Iron Phalanx',
+    category: 'apex',
+    faction: 'mechanicum',
+    subFaction: 'macrotek',
+    slots: [createSlotDefinition('armour', 3, 3), createSlotDefinition('heavy-transport', 3, 3)],
+    notes:
+      'Unlocked by Macrotek High Command. Units must have Vehicle type and Prime Conveyor rule.',
+  },
+  {
+    id: 'mech-thallax-command-cohort',
+    name: 'Thallax Command Cohort',
+    category: 'apex',
+    faction: 'mechanicum',
+    subFaction: 'reductor',
+    slots: [createSlotDefinition('support', 3, 3, { only: ['Thallax Cohort'] })],
+    notes: 'Unlocked by Reductor High Command. Slots may only be used for Thallax Cohort units.',
+  },
+];
+
+export function getAllMechanicumDetachments(): DetachmentDefinition[] {
+  return [...MECHANICUM_AUXILIARY_DETACHMENTS, ...MECHANICUM_APEX_DETACHMENTS];
+}

--- a/src/types/faction.ts
+++ b/src/types/faction.ts
@@ -35,7 +35,16 @@ export type LegionId =
   | 'blackshields'
   | 'shattered-legions';
 
-export type SubFactionId = LegionId;
+export type MechanicumArcanaId =
+  | 'archimandrite'
+  | 'cybernetica'
+  | 'lacrymaerta'
+  | 'myrmidax'
+  | 'reductor'
+  | 'malagra'
+  | 'macrotek';
+
+export type SubFactionId = LegionId | MechanicumArcanaId;
 
 export interface FactionDefinition {
   id: FactionId;
@@ -44,6 +53,7 @@ export interface FactionDefinition {
   canBeDetachmentFaction: boolean;
   canBePrimaryFaction: boolean;
   subFactions?: readonly SubFactionId[];
+  subFactionLabel?: string;
 }
 
 export interface SubFactionDefinition {
@@ -80,6 +90,7 @@ export const FACTIONS: readonly FactionDefinition[] = [
       'blackshields',
       'shattered-legions',
     ],
+    subFactionLabel: 'Legion',
   },
   {
     id: 'solar-auxilia',
@@ -92,6 +103,16 @@ export const FACTIONS: readonly FactionDefinition[] = [
     name: 'Mechanicum',
     canBeDetachmentFaction: true,
     canBePrimaryFaction: true,
+    subFactions: [
+      'archimandrite',
+      'cybernetica',
+      'lacrymaerta',
+      'myrmidax',
+      'reductor',
+      'malagra',
+      'macrotek',
+    ],
+    subFactionLabel: 'Arcana',
   },
   {
     id: 'imperialis-militia',
@@ -150,6 +171,7 @@ export const FACTIONS: readonly FactionDefinition[] = [
 ] as const;
 
 export const SUB_FACTIONS: readonly SubFactionDefinition[] = [
+  // Legiones Astartes
   { id: 'dark-angels', name: 'Dark Angels', parentFaction: 'legiones-astartes' },
   { id: 'emperors-children', name: "Emperor's Children", parentFaction: 'legiones-astartes' },
   { id: 'iron-warriors', name: 'Iron Warriors', parentFaction: 'legiones-astartes' },
@@ -170,6 +192,14 @@ export const SUB_FACTIONS: readonly SubFactionDefinition[] = [
   { id: 'alpha-legion', name: 'Alpha Legion', parentFaction: 'legiones-astartes' },
   { id: 'blackshields', name: 'Blackshields', parentFaction: 'legiones-astartes' },
   { id: 'shattered-legions', name: 'Shattered Legions', parentFaction: 'legiones-astartes' },
+  // Mechanicum
+  { id: 'archimandrite', name: 'Archimandrite', parentFaction: 'mechanicum' },
+  { id: 'cybernetica', name: 'Cybernetica', parentFaction: 'mechanicum' },
+  { id: 'lacrymaerta', name: 'Lacrymaerta', parentFaction: 'mechanicum' },
+  { id: 'myrmidax', name: 'Myrmidax', parentFaction: 'mechanicum' },
+  { id: 'reductor', name: 'Reductor', parentFaction: 'mechanicum' },
+  { id: 'malagra', name: 'Malagra', parentFaction: 'mechanicum' },
+  { id: 'macrotek', name: 'Macrotek', parentFaction: 'mechanicum' },
 ] as const;
 
 export function getFaction(id: FactionId): FactionDefinition | undefined {

--- a/src/ui/create-army.ts
+++ b/src/ui/create-army.ts
@@ -34,9 +34,9 @@ export function renderCreateArmy(): string {
           </select>
         </div>
         <div class="form-group" id="sub-faction-group" style="display: none;">
-          <label for="sub-faction">Sub-faction (Legion)</label>
+          <label for="sub-faction" id="sub-faction-label">Sub-faction</label>
           <select id="sub-faction" name="sub-faction">
-            <option value="">-- Select Legion --</option>
+            <option value="">-- Select --</option>
           </select>
         </div>
         <button type="submit" class="btn-primary">Create Army</button>
@@ -51,6 +51,7 @@ export function setupCreateArmyHandlers(): void {
   const factionSelect = document.getElementById('faction') as HTMLSelectElement;
   const subFactionGroup = document.getElementById('sub-faction-group') as HTMLDivElement;
   const subFactionSelect = document.getElementById('sub-faction') as HTMLSelectElement;
+  const subFactionLabel = document.getElementById('sub-faction-label') as HTMLLabelElement;
 
   function updateFactionOptions(): void {
     const allegiance = allegianceSelect.value as Allegiance;
@@ -79,13 +80,15 @@ export function setupCreateArmyHandlers(): void {
 
     if (faction?.subFactions && faction.subFactions.length > 0) {
       subFactionGroup.style.display = 'block';
+      const label = faction.subFactionLabel ?? 'Sub-faction';
+      subFactionLabel.textContent = label;
       const options = faction.subFactions
         .map((sfId) => {
           const sf = SUB_FACTIONS.find((s) => s.id === sfId);
           return `<option value="${sfId}">${sf?.name ?? sfId}</option>`;
         })
         .join('');
-      subFactionSelect.innerHTML = `<option value="">-- Select Legion --</option>${options}`;
+      subFactionSelect.innerHTML = `<option value="">-- Select ${label} --</option>${options}`;
     } else {
       subFactionGroup.style.display = 'none';
       subFactionSelect.innerHTML = '<option value="">-- None --</option>';


### PR DESCRIPTION
## Summary

- Adds 7 Mechanicum Arcana sub-factions: Archimandrite, Cybernetica, Lacrymaerta, Myrmidax, Reductor, Malagra, Macrotek
- Adds 2 auxiliary detachments: Taghmata Cohort, Apprentice Cadre
- Adds 7 apex detachments, one per Arcana (e.g., The Heart of Power for Archimandrite, Command Maniple for Cybernetica)
- Adds Magos and Magos on Abeyant command units with Officer of the Line 2
- Adds dynamic sub-faction labels so UI displays "Arcana" for Mechanicum instead of "Legion"

## Test plan

- [ ] Build passes (`pnpm build`)
- [ ] Tests pass (`pnpm test`)
- [ ] Create army with Mechanicum as primary faction
- [ ] Verify sub-faction dropdown shows "Arcana" label with 7 options
- [ ] Add units and verify detachment allocation works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)